### PR TITLE
Style elements are implicit in their tags

### DIFF
--- a/src/inline-styles-formatter.js
+++ b/src/inline-styles-formatter.js
@@ -3,7 +3,14 @@ define([], function () {
   'use strict';
 
   /* API helpers */
-  // TODO: move to shared place?
+
+  // these do not need to be wrapped because their style is
+  // implicit in their NodeType
+  var styleElements = ["B", "STRONG", "I", "EM", "U", "STRIKE"];
+
+  function isStyleElement(n) {
+    return styleElements.indexOf(n.nodeName);
+  }
 
   function isElement(node) {
     return node.nodeType === Node.ELEMENT_NODE;
@@ -36,7 +43,7 @@ define([], function () {
 
   function styleToElement(styleProp, styleValue, elName) {
     return function(n, mapper) {
-      if (isElement(n) && n.style[styleProp] === styleValue) {
+      if (isElement(n) && n.style[styleProp] === styleValue && !isStyleElement(n)) {
         var strongWrapper = document.createElement(elName);
         var child = n.firstChild;
         while (child) {

--- a/src/inline-styles-formatter.js
+++ b/src/inline-styles-formatter.js
@@ -6,7 +6,7 @@ define([], function () {
 
   // these do not need to be wrapped because their style is
   // implicit in their NodeType
-  var styleElements = ["B", "STRONG", "I", "EM", "U", "STRIKE"];
+  var styleElements = ["B", "STRONG", "I", "EM", "U", "STRIKE", "SUP", "SMALL", "SUB"];
 
   function isStyleElement(n) {
     return styleElements.indexOf(n.nodeName);


### PR DESCRIPTION
Prepare for a lengthy description.

Some tags such as B and STRONG etc. have their style implicit in their NodeType so if they have additional styling, this plugin should not convert them to a strong.

For example, if you paste:
`<strong style="font-weight: bold; margin-bottom: 0px; color: rgb(51, 51, 51); font-family: 'Guardian Egyptian Text', Georgia, serif; font-size: 16px; font-style: normal; font-variant: normal; letter-spacing: normal; line-height: 24px; orphans: auto; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(246, 246, 246);">emphasis</strong>`

The plugin will read the `font-weight` and turn the text node into a B element. This is clearly not correct, as you'll then end up with `<strong><b>text</b></strong>`.

This pull requests solves the problem by creating a list of elements that should not be wrapped e.g STRONG, B, etc. and skipping over them. Another way to do it is to convert the element into a B and then check it but I'm not really sure which one is the best. Also my list of elements might be a little incomplete.

\cc @theefer @robinedman @rrees 
